### PR TITLE
Requests with an ampersand will break the URL. This can even lead to …

### DIFF
--- a/src/lib/fetch_text.js
+++ b/src/lib/fetch_text.js
@@ -18,7 +18,7 @@ var fetch = function(page_identifier, lang_or_wikiid, cb) {
   }
   //we use the 'revisions' api here, instead of the Raw api, for its CORS-rules..
   url += '?action=query&prop=revisions&rvlimit=1&rvprop=content&format=json&origin=*';
-  url += '&' + identifier_type + '=' + page_identifier;
+  url += '&' + identifier_type + '=' + encodeURIComponent(page_identifier);
 
   request
     .get(url)


### PR DESCRIPTION
…an infinite loop: search A & B will get interpreted as A. The page for A might redirect to A & B for which the new search will repeat the same process